### PR TITLE
Add TA-Lib fallbacks

### DIFF
--- a/srv.py
+++ b/srv.py
@@ -23,7 +23,10 @@ import riskfolio as rp
 import seaborn as sns
 import statsmodels.api as sm
 import yfinance as yf
-import talib
+try:  # pragma: no cover - provide stubbed talib if not installed
+    import talib  # type: ignore
+except ModuleNotFoundError:
+    from signals import talib  # type: ignore
 from arch import arch_model
 from cachetools import TTLCache, cached
 from fastapi import FastAPI, Body, BackgroundTasks
@@ -2504,8 +2507,8 @@ async def async_http_get(url: str):
     try:
         async with httpx.AsyncClient() as client:
             response = await client.get(url, timeout=10.0)
-            # Create a requests-like response for compatibility
-            response.text = response.text
+            # httpx's Response object already mimics the requests.Response API
+            # so we can simply return it without modification.
             return response
     except Exception:
         # Fallback to synchronous version


### PR DESCRIPTION
## Summary
- provide a simple TA-Lib fallback in signals for test environments
- import the fallback from srv when the real library isn't available

## Testing
- `pytest test.py::TestPortfolioOptimization::test_format_tickers -q`

------
https://chatgpt.com/codex/tasks/task_e_684063759d84833299263e9346ec4b85